### PR TITLE
修改编程类题型参考程序输入控件的属性

### DIFF
--- a/trunk/onlineTest/judge/forms.py
+++ b/trunk/onlineTest/judge/forms.py
@@ -15,8 +15,8 @@ class ProblemAddForm(forms.Form):
                             required=False)
     output = forms.CharField(label='输出描述', widget=forms.Textarea(attrs={'class': 'form-control', 'rows': '3'}),
                              required=False)
-    sample_code = forms.CharField(label='参考程序', widget=forms.Textarea(attrs={'class': 'form-control', 'rows': '20', "spellcheck": "false",}),
-                            required=False)
+    sample_code = forms.CharField(label='参考答案', widget=forms.Textarea(attrs={'class': 'form-control', 'rows': '20', "spellcheck": "false",
+                'data-validation': 'required','data-validation-error-msg': "请输入参考答案"}))
     sample_input1 = forms.CharField(label='样例输入1', widget=forms.Textarea(attrs={'class': 'form-control', 'rows': '3'}),
                                     required=False)
     sample_output1 = forms.CharField(label='样例输出1', widget=forms.Textarea(attrs={'class': 'form-control', 'rows': '3'}),

--- a/trunk/onlineTest/judge/templates/problem_add.html
+++ b/trunk/onlineTest/judge/templates/problem_add.html
@@ -157,7 +157,7 @@
                         <span class="text-danger pull-right">{{ form.sample_code.errors }}</span>
                     {% endif %}
                     {{ form.sample_code }}
-                    <p class="text-muted">{{ form.output.help_text }}</p>
+                    <p class="text-muted">{{ form.sample_code.help_text }}</p>
                 </div>
 
                 <div class="form-group row">

--- a/trunk/onlineTest/judge/templates/problem_detail.html
+++ b/trunk/onlineTest/judge/templates/problem_detail.html
@@ -37,7 +37,7 @@
             <td>{{ problem.output }}</td>
         </tr>
         <tr>
-            <th>参考程序</th>
+            <th>参考答案</th>
             <td>{{ problem.sample_code }}</td>
         </tr>
         <tr>


### PR DESCRIPTION
将原标签名“参考程序”修改为“参考答案”，并要求textarea内容不能为空。
(onlineTest/judge/forms.py: 18)
(onlineTest/judge/problem_add.html: 160)
(onlineTest/judge/problem_detail.html: 40)